### PR TITLE
Fix tests to stub the with https

### DIFF
--- a/test/plugin/test_mesosphere.rb
+++ b/test/plugin/test_mesosphere.rb
@@ -36,13 +36,13 @@ class AmplifierFilterTest < Test::Unit::TestCase
   end
 
   def setup_marathon_container(container_id, file_name)
-    docker_api_url = "http://tcp//example.com:5422/v1.16/containers/#{container_id}/json"
+    docker_api_url = "https://example.com:5422/v1.16/containers/#{container_id}/json"
     file = File.open("test/containers/#{file_name}.json", 'rb')
     setup_docker_stub(file, docker_api_url)
   end
 
   def setup_chronos_container
-    docker_api_url = 'http://tcp//example.com:5422/v1.16/containers/foobar124/json'
+    docker_api_url = 'https://example.com:5422/v1.16/containers/foobar124/json'
     file = File.open('test/containers/chronos.json', 'rb')
     setup_docker_stub(file, docker_api_url)
   end
@@ -74,7 +74,7 @@ class AmplifierFilterTest < Test::Unit::TestCase
         d1.filter('log' => 'Hello World 4')
       end
     end
-    docker_api_url = 'http://tcp//example.com:5422/v1.16/containers/foobar123/json'
+    docker_api_url = 'https://example.com:5422/v1.16/containers/foobar123/json'
 
     assert_equal 1000, d1.filtered_as_array.length
     assert_requested(:get, docker_api_url, times: 2)
@@ -96,7 +96,7 @@ class AmplifierFilterTest < Test::Unit::TestCase
 
     Timecop.return
 
-    docker_api_url = 'http://tcp//example.com:5422/v1.16/containers/foobar123/json'
+    docker_api_url = 'https://example.com:5422/v1.16/containers/foobar123/json'
 
     assert_requested(:get, docker_api_url, times: 4)
   end
@@ -120,7 +120,7 @@ class AmplifierFilterTest < Test::Unit::TestCase
   end
 
   def test_chronos_bad_match
-    docker_api_url = 'http://tcp//example.com:5422/v1.16/containers/foobar124/json'
+    docker_api_url = 'https://example.com:5422/v1.16/containers/foobar124/json'
     file = File.open('test/containers/chronos_bad.json', 'rb')
     setup_docker_stub(file, docker_api_url)
 


### PR DESCRIPTION
I'm not sure what the difference is but my hypothesis is that the old set of stubs don't work with old docker versions (I'm on 1.6.1 currently).  Could be old docker parses urls in a more naive way and forces the protocol from tcp => https.  I was getting errors like:

```
  "this is stubbed"
  stub_request(:get, "http://tcp//example.com:5422/v1 ...

  "you need to stub this"
  stub_request(:get, "https://example.com:5422/v1 ...
```

And note this is how the docker url is set in the helper:

```
  Docker.url = 'tcp://example.com:5422'
```

Probably should not merge this if this fix doesn't work on newer docker.  Might be I should just upgrade.
