### PR TITLE
Add namespaces

### DIFF
--- a/test/containers/chronos.json
+++ b/test/containers/chronos.json
@@ -29,7 +29,8 @@
       "YEAR=2016",
       "VAULT_HOSTS=https://dev-use1a-pr-01-vault-vault-0001.dev-utopia.com:8200,https://dev-use1b-pr-01-vault-vault-0001.dev-utopia.com:8200,https://dev-use1e-pr-01-vault-vault-0001.dev-utopia.com:8200",
       "MESOS_SANDBOX=/mnt/mesos/sandbox",
-      "PORT=80"
+      "PORT=80",
+      "NAMESPACE=ns"
     ],
     "ExposedPorts": {
       "80/tcp": {}

--- a/test/containers/marathon.json
+++ b/test/containers/marathon.json
@@ -122,7 +122,8 @@
       "MARATHON_APP_ID=/hello-world",
       "FLUENTD_CONF=test.conf",
       "PATH=/home/ubuntu/ruby/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
-      "FLUENTD_OPT="
+      "FLUENTD_OPT=",
+      "NAMESPACE=ns"
     ],
     "Cmd": [
       "/bin/sh",

--- a/test/plugin/test_mesosphere.rb
+++ b/test/plugin/test_mesosphere.rb
@@ -152,6 +152,19 @@ class AmplifierFilterTest < Test::Unit::TestCase
     assert_equal 'Hello World', log_entry['test_key']
   end
 
+  def test_merge_json_with_namespace
+    setup_chronos_container
+
+    d1 = create_driver(CONFIG, 'docker.foobar124')
+    d1.run do
+      d1.filter('log' => '{"test_key":"Hello World"}', 'namespace' => 'ns')
+    end
+    filtered = d1.filtered_as_array
+    log_entry = filtered[0][2]
+
+    assert_equal 'Hello World', log_entry['ns']['test_key']
+  end
+
   def test_bad_merge_json
     setup_chronos_container
     bad_json1 = '{"test_key":"Hello World"'

--- a/test/plugin/test_mesosphere.rb
+++ b/test/plugin/test_mesosphere.rb
@@ -165,6 +165,7 @@ class AmplifierFilterTest < Test::Unit::TestCase
     filtered = d1.filtered_as_array
     log_entry = filtered[0][2]
 
+    assert_equal 'ns', log_entry['namespace']
     assert_equal 'Hello World', log_entry['ns']['test_key']
   end
 


### PR DESCRIPTION
The idea here is to allow users to configure a namespace for log messages, so that they don't collide.  I built it so that the docker container sets a namespace as an ENV var and then the plugin is configured to look at that ENV var.

In practice, for utopia:
- configure the plugin with `namespace_env_var UTOPIA_NAMESPACE`

Then:

```
  "environment": {
    "dev": { "UTOPIA_NAMESPACE": "dev.api-example" },
    "stg": { "UTOPIA_NAMESPACE": "stg.api-example" },
    "prd": { "UTOPIA_NAMESPACE": "prd.api-example" }
  }
```

Then the messages going into elastic should end up looking like:

```
{
  "namespace": "dev.api-example":
  "dev.api-example": {"key": "value"},
  "log":"{\"key\":\"value\"}",
  ...
}
```
